### PR TITLE
Reports table updates

### DIFF
--- a/api/database/models.py
+++ b/api/database/models.py
@@ -14,9 +14,9 @@ class Report(db.Model):
     # name
     name = Column(String(80), unique=True, nullable=True)
     # lat
-    lat = Column(Float(13), unique=False, nullable=True)
+    lat = Column(Float(13), unique=False, nullable=False)
     # long
-    long = Column(Float(13), unique=False, nullable=True)
+    long = Column(Float(13), unique=False, nullable=False)
     # description
     description = Column(String(250), unique=False, nullable=False)
     # event_type
@@ -29,18 +29,6 @@ class Report(db.Model):
             name = bleach.clean(name).strip()
             if name == '':
                 name = 'Anonymous'
-
-        if lat == '':
-          lat = None
-
-        if long == '':
-          long = None
-
-        if description == '':
-          description = None
-
-        if event_type == '':
-          event_type = None
 
         if image == '':
           image = None

--- a/api/resources/reports.py
+++ b/api/resources/reports.py
@@ -9,7 +9,8 @@ from api.database.models import Report
 
 def _validate_field(data, field, proceed, errors, missing_okay=False):
     if field in data:
-        data[field] = data[field].strip()
+        if type(data[field]) is str:
+            data[field] = data[field].strip()
         if len(str(data[field])) == 0:
             proceed = False
             errors.append(f"required '{field}' parameter is blank")
@@ -43,6 +44,10 @@ class ReportsResource(Resource):
             data, 'event_type', proceed, errors)
         proceed, report_description, errors = _validate_field(
             data, 'description', proceed, errors)
+        proceed, report_description, errors = _validate_field(
+            data, 'lat', proceed, errors)
+        proceed, report_description, errors = _validate_field(
+            data, 'long', proceed, errors)
 
         if proceed:
             report = Report(
@@ -80,13 +85,6 @@ class ReportsResource(Resource):
             'results': results
         }, 200
 class ReportResource(Resource):
-    """
-    this Resource file is for our /reports endpoints which do require
-    a resource ID in the URI path
-    GET /reports/6
-    DELETE /reports/3
-    PATCH /reports/18
-    """
     def get(self, *args, **kwargs):
         report_id = int(bleach.clean(kwargs['report_id'].strip()))
         report = None

--- a/migrations/versions/41059c651ae3_.py
+++ b/migrations/versions/41059c651ae3_.py
@@ -15,8 +15,8 @@ def upgrade():
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('name', sa.String(length=80), nullable=True),
     sa.Column('description', sa.String(length=250), nullable=False),
-    sa.Column('lat', sa.Float(), nullable=True),
-    sa.Column('long', sa.Float(), nullable=True),
+    sa.Column('lat', sa.Float(), nullable=False),
+    sa.Column('long', sa.Float(), nullable=False),
     sa.Column('event_type', sa.String(length=100), nullable=False),
     sa.Column('image', sa.String(length=100), nullable=True),
     sa.PrimaryKeyConstraint('id')

--- a/tests/endpoints/reports/test_create_report.py
+++ b/tests/endpoints/reports/test_create_report.py
@@ -78,7 +78,55 @@ class CreateReportTest(unittest.TestCase):
             self, links, 'index', str, '/api/v1/reports'
         )
 
-    def test_happypath_blank_latitude(self):
+    def test_happypath_blank_name(self):
+        payload = deepcopy(self.payload)
+        payload['name'] = ''
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(201, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, True)
+
+    # def test_happypath_missing_name(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['name']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(201, response.status_code)
+
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+
+    def test_happypath_blank_image(self):
+        payload = deepcopy(self.payload)
+        payload['image'] = ''
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(201, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, True)
+
+    # def test_happypath_missing_image(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['image']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(201, response.status_code)
+
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+
+    def test_sadpath_blank_latitude(self):
         payload = deepcopy(self.payload)
         payload['lat'] = ''
         response = self.client.post(
@@ -90,18 +138,51 @@ class CreateReportTest(unittest.TestCase):
         data = json.loads(response.data.decode('utf-8'))
         assert_payload_field_type_value(self, data, 'success', bool, True)
 
+    # def test_sadpath_missing_latitude(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['lat']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
 
-    def test_happypath_blank_longitude(self):
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'latitude' parameter is missing"]
+    #     )
+
+    def test_sadpath_missing_longitude(self):
         payload = deepcopy(self.payload)
-        payload['long'] = ''
+        del payload['long']
         response = self.client.post(
             '/api/v1/reports', json=payload,
             content_type='application/json'
         )
-        self.assertEqual(201, response.status_code)
+        self.assertEqual(400, response.status_code)
 
         data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, True)
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'longitude' parameter is missing"]
+        )
+
+    # def test_sadpath_blank_longitude(self):
+    #     payload = deepcopy(self.payload)
+    #     payload['long'] = ''
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(201, response.status_code)
+
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, True)
 
     def test_sadpath_missing_description(self):
         payload = deepcopy(self.payload)
@@ -119,6 +200,18 @@ class CreateReportTest(unittest.TestCase):
             self, data, 'errors', list,
             ["required 'description' parameter is missing"]
         )
+    
+    def test_sadpath_blank_description(self):
+        payload = deepcopy(self.payload)
+        payload['description'] = ''
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(201, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, True)
 
     def test_sadpath_blank_description(self):
         payload = deepcopy(self.payload)

--- a/tests/endpoints/reports/test_create_report.py
+++ b/tests/endpoints/reports/test_create_report.py
@@ -126,38 +126,9 @@ class CreateReportTest(unittest.TestCase):
     #     data = json.loads(response.data.decode('utf-8'))
     #     assert_payload_field_type_value(self, data, 'success', bool, False)
 
-    def test_sadpath_blank_latitude(self):
+    def test_sadpath_missing_latitude(self):
         payload = deepcopy(self.payload)
-        payload['lat'] = ''
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(201, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, True)
-
-    # def test_sadpath_missing_latitude(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['lat']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'latitude' parameter is missing"]
-    #     )
-
-    def test_sadpath_missing_longitude(self):
-        payload = deepcopy(self.payload)
-        del payload['long']
+        del payload['lat']
         response = self.client.post(
             '/api/v1/reports', json=payload,
             content_type='application/json'
@@ -169,20 +140,25 @@ class CreateReportTest(unittest.TestCase):
         assert_payload_field_type_value(self, data, 'error', int, 400)
         assert_payload_field_type_value(
             self, data, 'errors', list,
-            ["required 'longitude' parameter is missing"]
+            ["required 'lat' parameter is missing"]
         )
 
-    # def test_sadpath_blank_longitude(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['long'] = ''
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(201, response.status_code)
-
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, True)
+    def test_sadpath_missing_longitude(self):
+        payload = deepcopy(self.payload)
+        del payload['long']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        # import pdb; pdb.set_trace()
+        self.assertEqual(400, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'long' parameter is missing"]
+        )
 
     def test_sadpath_missing_description(self):
         payload = deepcopy(self.payload)
@@ -200,7 +176,7 @@ class CreateReportTest(unittest.TestCase):
             self, data, 'errors', list,
             ["required 'description' parameter is missing"]
         )
-    
+
     def test_sadpath_blank_description(self):
         payload = deepcopy(self.payload)
         payload['description'] = ''


### PR DESCRIPTION
Changes reports model to make lat and long un-nullable, and changes resource to send the fields through the validation method upon report creation. Also changes validation method to .strip the field value only if it is a string. Also changes the migration to make the attrs un-nullable but it is not necessary to drop / re-migrate for functionality to take effect. Sad path tests for missing lat and long updated, sadpath tests for empty fields removed because you can't really have an empty float.

- [x] Updated Files: api/database/models.py, api/resources/reports.py, tests/endpoints/reports/test_create_report.py

- [ ] Routes Added:

- [x] Sad Path Tested

- [x] Happy Path Tested

- [x] All Tests are passing

- [ ] Updated README.md with added information

- [x] Collaborators: @PhilipDeFraties 
