### PR TITLE
Reports table updates

### DIFF
--- a/api/database/models.py
+++ b/api/database/models.py
@@ -12,7 +12,7 @@ class Report(db.Model):
     # Auto-incrementing, unique primary key
     id = Column(Integer, primary_key=True)
     # name
-    name = Column(String(80), unique=True, nullable=True)
+    name = Column(String(80), nullable=True)
     # lat
     lat = Column(Float(13), unique=False, nullable=False)
     # long
@@ -22,22 +22,25 @@ class Report(db.Model):
     # event_type
     event_type = Column(String(100), unique=False, nullable=False)
     # image
-    image = Column(String(100), unique=False, nullable=True)
+    image = Column(String(100), nullable=True)
+    # city
+    city = Column(String(100), unique=False, nullable=False)
+    # state
+    state = Column(String(100), unique=False, nullable=False)
 
-    def __init__(self, name, lat, long, description, event_type, image, report_id=None):
+    def __init__(self, name, lat, long, description, event_type, city, state, image, report_id=None):
         if name is not None:
             name = bleach.clean(name).strip()
             if name == '':
                 name = 'Anonymous'
-
-        if image == '':
-          image = None
 
         self.name = name
         self.lat = lat
         self.long = long
         self.description = description
         self.event_type = event_type
+        self.city = city
+        self.state = state
         self.image = image
         if report_id is not None:
             self.id = report_id

--- a/api/resources/reports.py
+++ b/api/resources/reports.py
@@ -28,6 +28,8 @@ def _report_payload(report):
         'event_type': report.event_type,
         'description': report.description,
         'image': report.image,
+        'city': report.city,
+        'state': report.state,
         'links': {
             'get': f'/api/v1/reports/{report.id}',
             'delete': f'/api/v1/reports/{report.id}',
@@ -48,6 +50,10 @@ class ReportsResource(Resource):
             data, 'lat', proceed, errors)
         proceed, report_description, errors = _validate_field(
             data, 'long', proceed, errors)
+        proceed, report_description, errors = _validate_field(
+            data, 'city', proceed, errors)
+        proceed, report_description, errors = _validate_field(
+            data, 'state', proceed, errors)
 
         if proceed:
             report = Report(
@@ -56,7 +62,9 @@ class ReportsResource(Resource):
                 long=data['long'],
                 event_type=data['event_type'],
                 description=data['description'],
-                image=data['image']
+                image=data['image'],
+                city=data['city'],
+                state=data['state']
             )
             db.session.add(report)
             db.session.commit()

--- a/migrations/versions/41059c651ae3_.py
+++ b/migrations/versions/41059c651ae3_.py
@@ -20,7 +20,7 @@ def upgrade():
     sa.Column('event_type', sa.String(length=100), nullable=False),
     sa.Column('image', sa.String(length=100), nullable=True),
     sa.Column('city', sa.String(length=100), nullable=False),
-    sa.Column('state', sa.String(length=100), nullable=False)
+    sa.Column('state', sa.String(length=100), nullable=False),
     sa.PrimaryKeyConstraint('id')
     )
     # ### end Alembic commands ###

--- a/migrations/versions/41059c651ae3_.py
+++ b/migrations/versions/41059c651ae3_.py
@@ -19,6 +19,8 @@ def upgrade():
     sa.Column('long', sa.Float(), nullable=False),
     sa.Column('event_type', sa.String(length=100), nullable=False),
     sa.Column('image', sa.String(length=100), nullable=True),
+    sa.Column('city', sa.String(length=100), nullable=False),
+    sa.Column('state', sa.String(length=100), nullable=False)
     sa.PrimaryKeyConstraint('id')
     )
     # ### end Alembic commands ###

--- a/tests/endpoints/reports/test_create_report.py
+++ b/tests/endpoints/reports/test_create_report.py
@@ -32,101 +32,9 @@ class CreateReportTest(unittest.TestCase):
         db_drop_everything(db)
         self.app_context.pop()
 
-    # def test_happypath_create_report(self):
-    #     payload = deepcopy(self.payload)
-    #
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(201, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #
-    #     assert_payload_field_type_value(self, data, 'success', bool, True)
-    #
-    #     assert_payload_field_type(self, data, 'id', int)
-    #     report_id = data['id']
-    #     assert_payload_field_type_value(
-    #         self, data, 'name', str, payload['name'].strip()
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'lat', float, payload['lat']
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'long', float, payload['long']
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'description', str, payload['description'].strip()
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'event_type', str, payload['event_type'].strip()
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'image', str, payload['image'].strip()
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'city', str, payload['city'].strip()
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, data, 'state', str, payload['state'].strip()
-    #     )
-    #
-    #     assert_payload_field_type(self, data, 'links', dict)
-    #     links = data['links']
-    #     assert_payload_field_type_value(
-    #         self, links, 'get', str, f'/api/v1/reports/{report_id}'
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, links, 'patch', str, f'/api/v1/reports/{report_id}'
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, links, 'delete', str, f'/api/v1/reports/{report_id}'
-    #     )
-    #     assert_payload_field_type_value(
-    #         self, links, 'index', str, '/api/v1/reports'
-    #     )
-    #
-    # def test_happypath_blank_name(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['name'] = ''
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(201, response.status_code)
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, True)
-    #     assert_payload_field_type_value(self, data, 'name', str, 'Anonymous')
-    #
-    # # def test_happypath_missing_name(self):
-    # #     payload = deepcopy(self.payload)
-    # #     del payload['name']
-    # #     response = self.client.post(
-    # #         '/api/v1/reports', json=payload,
-    # #         content_type='application/json'
-    # #     )
-    # #
-    # #     self.assertEqual(201, response.status_code)
-    # #
-    # #     data = json.loads(response.data.decode('utf-8'))
-    # #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #
-    # def test_happypath_blank_image(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['image'] = ''
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(201, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, True)
-
-    def test_happypath_missing_image(self):
+    def test_happypath_create_report(self):
         payload = deepcopy(self.payload)
-        del payload['image']
+
         response = self.client.post(
             '/api/v1/reports', json=payload,
             content_type='application/json'
@@ -134,174 +42,266 @@ class CreateReportTest(unittest.TestCase):
         self.assertEqual(201, response.status_code)
 
         data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, False)
 
-    # def test_sadpath_missing_latitude(self):
+        assert_payload_field_type_value(self, data, 'success', bool, True)
+
+        assert_payload_field_type(self, data, 'id', int)
+        report_id = data['id']
+        assert_payload_field_type_value(
+            self, data, 'name', str, payload['name'].strip()
+        )
+        assert_payload_field_type_value(
+            self, data, 'lat', float, payload['lat']
+        )
+        assert_payload_field_type_value(
+            self, data, 'long', float, payload['long']
+        )
+        assert_payload_field_type_value(
+            self, data, 'description', str, payload['description'].strip()
+        )
+        assert_payload_field_type_value(
+            self, data, 'event_type', str, payload['event_type'].strip()
+        )
+        assert_payload_field_type_value(
+            self, data, 'image', str, payload['image'].strip()
+        )
+        assert_payload_field_type_value(
+            self, data, 'city', str, payload['city'].strip()
+        )
+        assert_payload_field_type_value(
+            self, data, 'state', str, payload['state'].strip()
+        )
+
+        assert_payload_field_type(self, data, 'links', dict)
+        links = data['links']
+        assert_payload_field_type_value(
+            self, links, 'get', str, f'/api/v1/reports/{report_id}'
+        )
+        assert_payload_field_type_value(
+            self, links, 'patch', str, f'/api/v1/reports/{report_id}'
+        )
+        assert_payload_field_type_value(
+            self, links, 'delete', str, f'/api/v1/reports/{report_id}'
+        )
+        assert_payload_field_type_value(
+            self, links, 'index', str, '/api/v1/reports'
+        )
+
+    def test_happypath_blank_name(self):
+        payload = deepcopy(self.payload)
+        payload['name'] = ''
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(201, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, True)
+        assert_payload_field_type_value(self, data, 'name', str, 'Anonymous')
+
+    # def test_happypath_missing_name(self):
     #     payload = deepcopy(self.payload)
-    #     del payload['lat']
+    #     del payload['name']
     #     response = self.client.post(
     #         '/api/v1/reports', json=payload,
     #         content_type='application/json'
     #     )
-    #     self.assertEqual(400, response.status_code)
+    #
+    #     self.assertEqual(201, response.status_code)
     #
     #     data = json.loads(response.data.decode('utf-8'))
     #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'lat' parameter is missing"]
-    #     )
-    #
-    # def test_sadpath_missing_longitude(self):
+
+    def test_happypath_blank_image(self):
+        payload = deepcopy(self.payload)
+        payload['image'] = ''
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(201, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, True)
+
+    # def test_happypath_missing_image(self):
     #     payload = deepcopy(self.payload)
-    #     del payload['long']
+    #     del payload['image']
     #     response = self.client.post(
     #         '/api/v1/reports', json=payload,
     #         content_type='application/json'
     #     )
-    #     # import pdb; pdb.set_trace()
-    #     self.assertEqual(400, response.status_code)
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'long' parameter is missing"]
-    #     )
-    #
-    # def test_sadpath_missing_description(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['description']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
+    #     self.assertEqual(201, response.status_code)
     #
     #     data = json.loads(response.data.decode('utf-8'))
     #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'description' parameter is missing"]
-    #     )
-    #
-    # def test_sadpath_blank_description(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['description'] = ''
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'description' parameter is blank"]
-    #     )
-    #
-    # def test_sadpath_missing_event_type(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['event_type']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'event_type' parameter is missing"]
-    #     )
-    #
-    # def test_sadpath_blank_event_type(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['event_type'] = ' '
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'event_type' parameter is blank"]
-    #     )
-    #
-    # def test_sadpath_blank_city(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['city'] = ' '
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'city' parameter is blank"]
-    #     )
-    #
-    # def test_sadpath_missing_city(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['city']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'city' parameter is missing"]
-    #     )
-    #
-    # def test_sadpath_blank_state(self):
-    #     payload = deepcopy(self.payload)
-    #     payload['state'] = ' '
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'state' parameter is blank"]
-    #     )
-    #
-    # def test_sadpath_missing_state(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['state']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(400, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-    #     assert_payload_field_type_value(self, data, 'error', int, 400)
-    #     assert_payload_field_type_value(
-    #         self, data, 'errors', list,
-    #         ["required 'state' parameter is missing"]
-    #     )
+
+    def test_sadpath_missing_latitude(self):
+        payload = deepcopy(self.payload)
+        del payload['lat']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'lat' parameter is missing"]
+        )
+
+    def test_sadpath_missing_longitude(self):
+        payload = deepcopy(self.payload)
+        del payload['long']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        # import pdb; pdb.set_trace()
+        self.assertEqual(400, response.status_code)
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'long' parameter is missing"]
+        )
+
+    def test_sadpath_missing_description(self):
+        payload = deepcopy(self.payload)
+        del payload['description']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'description' parameter is missing"]
+        )
+
+    def test_sadpath_blank_description(self):
+        payload = deepcopy(self.payload)
+        payload['description'] = ''
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'description' parameter is blank"]
+        )
+
+    def test_sadpath_missing_event_type(self):
+        payload = deepcopy(self.payload)
+        del payload['event_type']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'event_type' parameter is missing"]
+        )
+
+    def test_sadpath_blank_event_type(self):
+        payload = deepcopy(self.payload)
+        payload['event_type'] = ' '
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'event_type' parameter is blank"]
+        )
+
+    def test_sadpath_blank_city(self):
+        payload = deepcopy(self.payload)
+        payload['city'] = ' '
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'city' parameter is blank"]
+        )
+
+    def test_sadpath_missing_city(self):
+        payload = deepcopy(self.payload)
+        del payload['city']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'city' parameter is missing"]
+        )
+
+    def test_sadpath_blank_state(self):
+        payload = deepcopy(self.payload)
+        payload['state'] = ' '
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'state' parameter is blank"]
+        )
+
+    def test_sadpath_missing_state(self):
+        payload = deepcopy(self.payload)
+        del payload['state']
+        response = self.client.post(
+            '/api/v1/reports', json=payload,
+            content_type='application/json'
+        )
+        self.assertEqual(400, response.status_code)
+
+        data = json.loads(response.data.decode('utf-8'))
+        assert_payload_field_type_value(self, data, 'success', bool, False)
+        assert_payload_field_type_value(self, data, 'error', int, 400)
+        assert_payload_field_type_value(
+            self, data, 'errors', list,
+            ["required 'state' parameter is missing"]
+        )

--- a/tests/endpoints/reports/test_create_report.py
+++ b/tests/endpoints/reports/test_create_report.py
@@ -23,6 +23,8 @@ class CreateReportTest(unittest.TestCase):
             'description': 'They had really cute buggey eyes :D',
             'event_type': 'abduction',
             'image': 'image.jpg',
+            'city': 'Greeley',
+            'state': 'CO'
         }
 
     def tearDown(self):
@@ -30,156 +32,101 @@ class CreateReportTest(unittest.TestCase):
         db_drop_everything(db)
         self.app_context.pop()
 
-    def test_happypath_create_report(self):
-        payload = deepcopy(self.payload)
-
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(201, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, True)
-
-        assert_payload_field_type(self, data, 'id', int)
-        report_id = data['id']
-        assert_payload_field_type_value(
-            self, data, 'name', str, payload['name'].strip()
-        )
-        assert_payload_field_type_value(
-            self, data, 'lat', float, payload['lat']
-        )
-        assert_payload_field_type_value(
-            self, data, 'long', float, payload['long']
-        )
-        assert_payload_field_type_value(
-            self, data, 'description', str, payload['description'].strip()
-        )
-        assert_payload_field_type_value(
-            self, data, 'event_type', str, payload['event_type'].strip()
-        )
-        assert_payload_field_type_value(
-            self, data, 'image', str, payload['image'].strip()
-        )
-
-        assert_payload_field_type(self, data, 'links', dict)
-        links = data['links']
-        assert_payload_field_type_value(
-            self, links, 'get', str, f'/api/v1/reports/{report_id}'
-        )
-        assert_payload_field_type_value(
-            self, links, 'patch', str, f'/api/v1/reports/{report_id}'
-        )
-        assert_payload_field_type_value(
-            self, links, 'delete', str, f'/api/v1/reports/{report_id}'
-        )
-        assert_payload_field_type_value(
-            self, links, 'index', str, '/api/v1/reports'
-        )
-
-    def test_happypath_blank_name(self):
-        payload = deepcopy(self.payload)
-        payload['name'] = ''
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(201, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, True)
-
-    # def test_happypath_missing_name(self):
+    # def test_happypath_create_report(self):
     #     payload = deepcopy(self.payload)
-    #     del payload['name']
+    #
     #     response = self.client.post(
     #         '/api/v1/reports', json=payload,
     #         content_type='application/json'
     #     )
     #     self.assertEqual(201, response.status_code)
-
+    #
     #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-
-    def test_happypath_blank_image(self):
-        payload = deepcopy(self.payload)
-        payload['image'] = ''
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(201, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, True)
-
-    # def test_happypath_missing_image(self):
+    #
+    #     assert_payload_field_type_value(self, data, 'success', bool, True)
+    #
+    #     assert_payload_field_type(self, data, 'id', int)
+    #     report_id = data['id']
+    #     assert_payload_field_type_value(
+    #         self, data, 'name', str, payload['name'].strip()
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'lat', float, payload['lat']
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'long', float, payload['long']
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'description', str, payload['description'].strip()
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'event_type', str, payload['event_type'].strip()
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'image', str, payload['image'].strip()
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'city', str, payload['city'].strip()
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, data, 'state', str, payload['state'].strip()
+    #     )
+    #
+    #     assert_payload_field_type(self, data, 'links', dict)
+    #     links = data['links']
+    #     assert_payload_field_type_value(
+    #         self, links, 'get', str, f'/api/v1/reports/{report_id}'
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, links, 'patch', str, f'/api/v1/reports/{report_id}'
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, links, 'delete', str, f'/api/v1/reports/{report_id}'
+    #     )
+    #     assert_payload_field_type_value(
+    #         self, links, 'index', str, '/api/v1/reports'
+    #     )
+    #
+    # def test_happypath_blank_name(self):
     #     payload = deepcopy(self.payload)
-    #     del payload['image']
+    #     payload['name'] = ''
     #     response = self.client.post(
     #         '/api/v1/reports', json=payload,
     #         content_type='application/json'
     #     )
     #     self.assertEqual(201, response.status_code)
-
     #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'success', bool, True)
+    #     assert_payload_field_type_value(self, data, 'name', str, 'Anonymous')
+    #
+    # # def test_happypath_missing_name(self):
+    # #     payload = deepcopy(self.payload)
+    # #     del payload['name']
+    # #     response = self.client.post(
+    # #         '/api/v1/reports', json=payload,
+    # #         content_type='application/json'
+    # #     )
+    # #
+    # #     self.assertEqual(201, response.status_code)
+    # #
+    # #     data = json.loads(response.data.decode('utf-8'))
+    # #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #
+    # def test_happypath_blank_image(self):
+    #     payload = deepcopy(self.payload)
+    #     payload['image'] = ''
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(201, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, True)
 
-    def test_sadpath_missing_latitude(self):
+    def test_happypath_missing_image(self):
         payload = deepcopy(self.payload)
-        del payload['lat']
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(400, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, False)
-        assert_payload_field_type_value(self, data, 'error', int, 400)
-        assert_payload_field_type_value(
-            self, data, 'errors', list,
-            ["required 'lat' parameter is missing"]
-        )
-
-    def test_sadpath_missing_longitude(self):
-        payload = deepcopy(self.payload)
-        del payload['long']
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        # import pdb; pdb.set_trace()
-        self.assertEqual(400, response.status_code)
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, False)
-        assert_payload_field_type_value(self, data, 'error', int, 400)
-        assert_payload_field_type_value(
-            self, data, 'errors', list,
-            ["required 'long' parameter is missing"]
-        )
-
-    def test_sadpath_missing_description(self):
-        payload = deepcopy(self.payload)
-        del payload['description']
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(400, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, False)
-        assert_payload_field_type_value(self, data, 'error', int, 400)
-        assert_payload_field_type_value(
-            self, data, 'errors', list,
-            ["required 'description' parameter is missing"]
-        )
-
-    def test_sadpath_blank_description(self):
-        payload = deepcopy(self.payload)
-        payload['description'] = ''
+        del payload['image']
         response = self.client.post(
             '/api/v1/reports', json=payload,
             content_type='application/json'
@@ -187,55 +134,174 @@ class CreateReportTest(unittest.TestCase):
         self.assertEqual(201, response.status_code)
 
         data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, True)
-
-    def test_sadpath_blank_description(self):
-        payload = deepcopy(self.payload)
-        payload['description'] = ''
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(400, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
         assert_payload_field_type_value(self, data, 'success', bool, False)
-        assert_payload_field_type_value(self, data, 'error', int, 400)
-        assert_payload_field_type_value(
-            self, data, 'errors', list,
-            ["required 'description' parameter is blank"]
-        )
 
-    def test_sadpath_missing_event_type(self):
-        payload = deepcopy(self.payload)
-        del payload['event_type']
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(400, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, False)
-        assert_payload_field_type_value(self, data, 'error', int, 400)
-        assert_payload_field_type_value(
-            self, data, 'errors', list,
-            ["required 'event_type' parameter is missing"]
-        )
-
-    def test_sadpath_blank_event_type(self):
-        payload = deepcopy(self.payload)
-        payload['event_type'] = ' '
-        response = self.client.post(
-            '/api/v1/reports', json=payload,
-            content_type='application/json'
-        )
-        self.assertEqual(400, response.status_code)
-
-        data = json.loads(response.data.decode('utf-8'))
-        assert_payload_field_type_value(self, data, 'success', bool, False)
-        assert_payload_field_type_value(self, data, 'error', int, 400)
-        assert_payload_field_type_value(
-            self, data, 'errors', list,
-            ["required 'event_type' parameter is blank"]
-        )
+    # def test_sadpath_missing_latitude(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['lat']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'lat' parameter is missing"]
+    #     )
+    #
+    # def test_sadpath_missing_longitude(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['long']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     # import pdb; pdb.set_trace()
+    #     self.assertEqual(400, response.status_code)
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'long' parameter is missing"]
+    #     )
+    #
+    # def test_sadpath_missing_description(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['description']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'description' parameter is missing"]
+    #     )
+    #
+    # def test_sadpath_blank_description(self):
+    #     payload = deepcopy(self.payload)
+    #     payload['description'] = ''
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'description' parameter is blank"]
+    #     )
+    #
+    # def test_sadpath_missing_event_type(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['event_type']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'event_type' parameter is missing"]
+    #     )
+    #
+    # def test_sadpath_blank_event_type(self):
+    #     payload = deepcopy(self.payload)
+    #     payload['event_type'] = ' '
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'event_type' parameter is blank"]
+    #     )
+    #
+    # def test_sadpath_blank_city(self):
+    #     payload = deepcopy(self.payload)
+    #     payload['city'] = ' '
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'city' parameter is blank"]
+    #     )
+    #
+    # def test_sadpath_missing_city(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['city']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'city' parameter is missing"]
+    #     )
+    #
+    # def test_sadpath_blank_state(self):
+    #     payload = deepcopy(self.payload)
+    #     payload['state'] = ' '
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'state' parameter is blank"]
+    #     )
+    #
+    # def test_sadpath_missing_state(self):
+    #     payload = deepcopy(self.payload)
+    #     del payload['state']
+    #     response = self.client.post(
+    #         '/api/v1/reports', json=payload,
+    #         content_type='application/json'
+    #     )
+    #     self.assertEqual(400, response.status_code)
+    #
+    #     data = json.loads(response.data.decode('utf-8'))
+    #     assert_payload_field_type_value(self, data, 'success', bool, False)
+    #     assert_payload_field_type_value(self, data, 'error', int, 400)
+    #     assert_payload_field_type_value(
+    #         self, data, 'errors', list,
+    #         ["required 'state' parameter is missing"]
+    #     )

--- a/tests/endpoints/reports/test_delete_report.py
+++ b/tests/endpoints/reports/test_delete_report.py
@@ -15,7 +15,16 @@ class DeleteReportTest(unittest.TestCase):
         db.create_all()
         self.client = self.app.test_client()
 
-        self.report_1 = Report(name='Phil', lat=3.123123, long=3.345345, description="some crazy stuff happened", event_type="abduction", image="image.com")
+        self.report_1 = Report(
+            name='Phil',
+            lat=3.123123,
+            long=3.345345,
+            description="some crazy stuff happened",
+            event_type="abduction",
+            image="image.com",
+            city="Greeley",
+            state="CO"
+            )
         self.report_1.insert()
 
     def tearDown(self):


### PR DESCRIPTION
Adds city and state attrs to report model and migration nullable=False, sends fields through validation in reports resource upon creation, adds fields to return payload, adds sadpath tests and updates happy tests
*I cannot figure out how to make a post request go through with entirely missing fields, I've tried everything I can think of and nothing allows a report to be made if any fields are missing entirely, those happy tests are still commented out*
- [x] Updated Files: report model, migration, resource, create and delete endpoint tests

- [ ] Routes Added:

- [x] Sad Path Tested

- [x] Happy Path Tested

- [x] All Tests are passing

- [ ] Updated README.md with added information

- [ ] Collaborators: @PhilipDeFraties 
