### PR TITLE
Tests refactor

### DIFF
--- a/api/database/models.py
+++ b/api/database/models.py
@@ -44,6 +44,18 @@ class Report(db.Model):
         if image == '':
           image = None
 
+        if city == '':
+          city = None
+
+        if state == '':
+          state = None
+
+        if description == '':
+          description = None
+
+        if event_type == '':
+          event_type = None
+
         self.name = name
         self.lat = lat
         self.long = long
@@ -74,7 +86,7 @@ class Comment(db.Model):
 
     id = Column(Integer, primary_key=True)
     text = Column(String, nullable=False)
-    report_id = Column(Integer, ForeignKey('reports.id'))
+    report_id = Column(Integer, ForeignKey('reports.id'), nullable=False)
     created_at = Column(db.DateTime, nullable=False, default=datetime.utcnow)
 
     def __init__(self, text, report_id, comment_id=None):

--- a/api/resources/comments.py
+++ b/api/resources/comments.py
@@ -19,6 +19,7 @@ def _validate_field(data, field, proceed, errors, missing_okay=False):
         errors.append(f"required '{field}' parameter is missing")
         data[field] = ''
     return proceed, data[field], errors
+
 def _comment_payload(comment):
     return {
         'text': comment.text,
@@ -43,6 +44,7 @@ class CommentsResource(Resource):
             return comment, errors
         else:
             return None, errors
+
     def post(self, *args, **kwargs):
         comment, errors = self._create_comment(json.loads(request.data))
         if comment is not None:

--- a/api/resources/reports.py
+++ b/api/resources/reports.py
@@ -25,6 +25,7 @@ def _validate_field(data, field, proceed, errors, missing_okay=False):
         errors.append(f"required '{field}' parameter is missing")
         data[field] = ''
     return proceed, data[field], errors
+
 def _report_payload(report):
     return {
         'id': report.id,
@@ -45,6 +46,7 @@ def _report_payload(report):
             'patch': f'/api/v1/reports/{report.id}'
         }
     }
+
 def _reports_payload(report):
     return {
         'id': report.id,
@@ -98,6 +100,7 @@ class ReportsResource(Resource):
             return report, errors
         else:
             return None, errors
+
     def post(self, *args, **kwargs):
         report, errors = self._create_report(json.loads(request.data))
         if report is not None:
@@ -110,6 +113,7 @@ class ReportsResource(Resource):
                 'error': 400,
                 'errors': errors
             }, 400
+
     def get(self, *args, **kwargs):
         reports = Report.query.order_by(
             Report.name.asc()
@@ -119,6 +123,7 @@ class ReportsResource(Resource):
             'success': True,
             'results': results
         }, 200
+
 class ReportResource(Resource):
     def get(self, *args, **kwargs):
         report_id = int(bleach.clean(kwargs['report_id'].strip()))
@@ -130,6 +135,7 @@ class ReportResource(Resource):
         report_payload = _report_payload(report)
         report_payload['success'] = True
         return report_payload, 200
+        
     def delete(self, *args, **kwargs):
         report_id = kwargs['report_id']
         report = None

--- a/migrations/versions/3e9a63fc790d_.py
+++ b/migrations/versions/3e9a63fc790d_.py
@@ -1,8 +1,8 @@
 """empty message
 
-Revision ID: 719e47144eec
+Revision ID: 3e9a63fc790d
 Revises: 
-Create Date: 2021-02-27 13:29:45.612612
+Create Date: 2021-03-01 11:01:47.367938
 
 """
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = '719e47144eec'
+revision = '3e9a63fc790d'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -34,7 +34,7 @@ def upgrade():
     op.create_table('comments',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('text', sa.String(), nullable=False),
-    sa.Column('report_id', sa.Integer(), nullable=True),
+    sa.Column('report_id', sa.Integer(), nullable=False),
     sa.Column('created_at', sa.DateTime(), nullable=False),
     sa.ForeignKeyConstraint(['report_id'], ['reports.id'], ),
     sa.PrimaryKeyConstraint('id')

--- a/tests/endpoints/reports/test_create_report.py
+++ b/tests/endpoints/reports/test_create_report.py
@@ -99,19 +99,6 @@ class CreateReportTest(unittest.TestCase):
         assert_payload_field_type_value(self, data, 'success', bool, True)
         assert_payload_field_type_value(self, data, 'name', str, 'Anonymous')
 
-    # def test_happypath_missing_name(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['name']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-
-    #     self.assertEqual(201, response.status_code)
-    
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
-
     def test_happypath_blank_image(self):
         payload = deepcopy(self.payload)
         payload['image'] = ' '
@@ -123,18 +110,6 @@ class CreateReportTest(unittest.TestCase):
 
         data = json.loads(response.data.decode('utf-8'))
         assert_payload_field_type_value(self, data, 'success', bool, True)
-
-    # def test_happypath_missing_image(self):
-    #     payload = deepcopy(self.payload)
-    #     del payload['image']
-    #     response = self.client.post(
-    #         '/api/v1/reports', json=payload,
-    #         content_type='application/json'
-    #     )
-    #     self.assertEqual(201, response.status_code)
-    #
-    #     data = json.loads(response.data.decode('utf-8'))
-    #     assert_payload_field_type_value(self, data, 'success', bool, False)
 
     def test_sadpath_blank_latitude(self):
         payload = deepcopy(self.payload)
@@ -194,8 +169,8 @@ class CreateReportTest(unittest.TestCase):
             '/api/v1/reports', json=payload,
             content_type='application/json'
         )
-        # import pdb; pdb.set_trace()
         self.assertEqual(400, response.status_code)
+        
         data = json.loads(response.data.decode('utf-8'))
         assert_payload_field_type_value(self, data, 'success', bool, False)
         assert_payload_field_type_value(self, data, 'error', int, 400)

--- a/tests/models/test_comments.py
+++ b/tests/models/test_comments.py
@@ -44,19 +44,19 @@ class AppTest(unittest.TestCase):
         self.assertEqual(1, comment.id)
         self.assertEqual('I knew it!', comment.text)
 
-    # def test_report_model_missing_text(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         comment = Comment(report_id={report.id})
-    #         report.comments.append(comment)
-    #         db.session.add(report)
-    #         db.session.commit()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
+    def test_report_model_missing_text(self):
+        try:
+            report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
+                            description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
+            comment = Comment(text=None, report_id={report.id})
+            report.comments.append(comment)
+            db.session.add(report)
+            db.session.commit()
+        except IntegrityError:
+            self.assertTrue(True)
+        else:
+            # we should not end up in here
+            self.assertTrue(False)  # pragma: no cover
 
     def test_report_model_blank_text(self):
         try:
@@ -72,30 +72,17 @@ class AppTest(unittest.TestCase):
             # we should not end up in here
             self.assertTrue(False)  # pragma: no cover
 
-    # def test_report_model_missing_report_id(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         comment = Comment(text='I knew it!', report_id='')
-    #         report.comments.append(comment)
-    #         db.session.add(report)
-    #         db.session.commit()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
-
-    # def test_report_model_blank_report_id(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         comment = Comment(text='I knew it!', report_id=None)
-    #         report.comments.append(comment)
-    #         db.session.add(report)
-    #         db.session.commit()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
+    def test_report_model_blank_report_id(self):
+        try:
+            report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
+                            description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
+            comment = Comment(text='I knew it!', report_id=None)
+            # report.comments.append(comment)
+            db.session.add(report)
+            db.session.add(comment)
+            db.session.commit()
+        except IntegrityError:
+            self.assertTrue(True)
+        else:
+            # we should not end up in here
+            self.assertTrue(False)  # pragma: no cover

--- a/tests/models/test_report.py
+++ b/tests/models/test_report.py
@@ -71,17 +71,6 @@ class AppTest(unittest.TestCase):
             # we should not end up in here
             self.assertTrue(True)  # pragma: no cover
 
-    # def test_report_model_blank_lat(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat='', long=3.345, city='Roswell', state='NM',
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         report.insert()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
-
     def test_report_model_missing_lat(self):
         try:
             report = Report(name='Mark Zuckerberg', lat=None, long=3.345, city='Roswell', state='NM',
@@ -92,17 +81,6 @@ class AppTest(unittest.TestCase):
         else:
             # we should not end up in here
             self.assertTrue(False)  # pragma: no cover
-
-    # def test_report_model_blank_long(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long='', city='Roswell', state='NM',
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         report.insert()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
 
     def test_report_model_missing_long(self):
         try:
@@ -121,21 +99,21 @@ class AppTest(unittest.TestCase):
                             description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
             report.insert()
         except IntegrityError:
-            self.assertTrue(False)
+            self.assertTrue(True)
         else:
             # we should not end up in here
-            self.assertTrue(True)  # pragma: no cover
+            self.assertTrue(False)  # pragma: no cover
 
-    # def test_report_model_missing_city(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city=None, state='NM',
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         report.insert()
-    #     except IntegrityError:
-    #         self.assertTrue(False)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(True)  # pragma: no cover
+    def test_report_model_missing_city(self):
+        try:
+            report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city=None, state='NM',
+                            description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
+            report.insert()
+        except IntegrityError:
+            self.assertTrue(True)
+        else:
+            # we should not end up in here
+            self.assertTrue(False)  # pragma: no cover
 
     def test_report_model_blank_state(self):
         try:
@@ -143,32 +121,32 @@ class AppTest(unittest.TestCase):
                             description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
             report.insert()
         except IntegrityError:
-            self.assertTrue(False)
+            self.assertTrue(True)
         else:
             # we should not end up in here
-            self.assertTrue(True)  # pragma: no cover
+            self.assertTrue(False)  # pragma: no cover
 
-    # def test_report_model_missing_state(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state=None,
-    #                         description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
-    #         report.insert()
-    #     except IntegrityError:
-    #         self.assertTrue(False)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(True)  # pragma: no cover
+    def test_report_model_missing_state(self):
+        try:
+            report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state=None,
+                            description="I am your reptilian overloard!", event_type="encounter", image="pics.com")
+            report.insert()
+        except IntegrityError:
+            self.assertTrue(True)
+        else:
+            # we should not end up in here
+            self.assertTrue(False)  # pragma: no cover
 
-    # def test_report_model_blank_description(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
-    #                         description='', event_type="encounter", image="pics.com")
-    #         report.insert()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
+    def test_report_model_blank_description(self):
+        try:
+            report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
+                            description='', event_type="encounter", image="pics.com")
+            report.insert()
+        except IntegrityError:
+            self.assertTrue(True)
+        else:
+            # we should not end up in here
+            self.assertTrue(False)  # pragma: no cover
 
     def test_report_model_missing_description(self):
         try:
@@ -181,16 +159,16 @@ class AppTest(unittest.TestCase):
             # we should not end up in here
             self.assertTrue(False)  # pragma: no cover
 
-    # def test_report_model_blank_event_type(self):
-    #     try:
-    #         report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
-    #                         description='I am your reptilian overloard!', event_type='', image="pics.com")
-    #         report.insert()
-    #     except IntegrityError:
-    #         self.assertTrue(True)
-    #     else:
-    #         # we should not end up in here
-    #         self.assertTrue(False)  # pragma: no cover
+    def test_report_model_blank_event_type(self):
+        try:
+            report = Report(name='Mark Zuckerberg', lat=3.123, long=3.345, city='Roswell', state='NM',
+                            description='I am your reptilian overloard!', event_type='', image="pics.com")
+            report.insert()
+        except IntegrityError:
+            self.assertTrue(True)
+        else:
+            # we should not end up in here
+            self.assertTrue(False)  # pragma: no cover
 
     def test_report_model_missing_event_type(self):
         try:


### PR DESCRIPTION
Delete happy path tests for missing fields
Update comments migration with report_id as non-nullable
Add sad path for blank field to comment and report model
Add spacing between methods

- [x] Updated Files: database/models.py, resources/comments.py, resources/reports.py, test_create_report.py, test_comments.py, test_reports.py, migartions

- [ ] Routes Added:

- [x] Sad Path Tested

- [x] Happy Path Tested

- [x] All Tests are passing

- [ ] Updated README.md with added information

- [x] Collaborators: @evilaspaas1 @Todd-Estes @PhilipDeFraties 
